### PR TITLE
Update the check condition of process.env.GITHUB_HEAD_REF

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3533,10 +3533,14 @@ function getSource(openj9Version, usePersonalRepo) {
             const repo = process.env.GITHUB_REPOSITORY;
             let branch = '';
             if ('GITHUB_HEAD_REF' in process.env) {
+                core.info('GIT_HUB_REF is exist');
                 branch = process.env.GITHUB_HEAD_REF;
+                core.info(`branh is ${branch}`);
             }
             else {
+                core.info('GITHUB_REF is exist');
                 const ref = process.env.GITHUB_REF;
+                core.info(`ref is ${ref}`);
                 branch = ref.substr(ref.lastIndexOf('/') + 1);
             }
             if (repo.includes(`/${openj9Version}`)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3532,16 +3532,12 @@ function getSource(openj9Version, usePersonalRepo) {
         if (usePersonalRepo) {
             const repo = process.env.GITHUB_REPOSITORY;
             let branch = '';
-            if ('GITHUB_HEAD_REF' in process.env) {
-                core.info('GIT_HUB_REF is exist');
-                branch = process.env.GITHUB_HEAD_REF;
-                core.info(`branh is ${branch}`);
+            if (process.env.GITHUB_HEAD_REF === '') {
+                const ref = process.env.GITHUB_REF;
+                branch = ref.substr(ref.lastIndexOf('/') + 1);
             }
             else {
-                core.info('GITHUB_REF is exist');
-                const ref = process.env.GITHUB_REF;
-                core.info(`ref is ${ref}`);
-                branch = ref.substr(ref.lastIndexOf('/') + 1);
+                branch = process.env.GITHUB_HEAD_REF;
             }
             if (repo.includes(`/${openj9Version}`)) {
                 openjdkOpenj9Repo = repo;

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -255,15 +255,11 @@ async function getSource(
   if (usePersonalRepo) {
     const repo = process.env.GITHUB_REPOSITORY as string
     let branch = ''
-    if ('GITHUB_HEAD_REF' in process.env) {
-      core.info('GIT_HUB_REF is exist')
-      branch = process.env.GITHUB_HEAD_REF as string
-      core.info(`branh is ${branch}`)
-    } else {
-      core.info('GITHUB_REF is exist')
+    if (process.env.GITHUB_HEAD_REF === '') {
       const ref = process.env.GITHUB_REF as string
-      core.info(`ref is ${ref}`)
       branch = ref.substr(ref.lastIndexOf('/') + 1)
+    } else {
+      branch = process.env.GITHUB_HEAD_REF as string
     }
 
     if (repo.includes(`/${openj9Version}`)) {


### PR DESCRIPTION
The check is to determine the push branch. Looks like github action environment variable set is changed. GITHUB_HEAD_REF was only set for pull request and now it is also set for push with value as empty.

We will check if the value is empty instead of checking if it is set as environment variable to make this if condition works